### PR TITLE
Prevent caching on config.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ FROM nginx:mainline-alpine as server
 
 WORKDIR /usr/share/nginx/html
 
+COPY default.conf /etc/nginx/conf.d/
+
 COPY  --from=builder /app/build ./

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    location /config.json {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache";
+    }
+}


### PR DESCRIPTION
I would suggest adding this block in the nginx config so that the config.json doesn't get cached from disk once you need to reload it.

```
    location /config.json {
        root   /usr/share/nginx/html;
        add_header Cache-Control "no-store, no-cache";
    }
```

So, I took the original config file from nginx and added this block.