### PR TITLE
feat: support per-link target configuration

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -7,6 +7,11 @@ export interface Props extends HTMLAttributes<HTMLElement> {
   background?: string
   highlight: boolean
   className?: string
+  /**
+   * Sets where the link should open.
+   * Defaults to `_blank`.
+   */
+  target?: string
 }
 
 const Card: FC<Props> = ({
@@ -15,6 +20,7 @@ const Card: FC<Props> = ({
   children,
   highlight,
   className = '',
+  target,
   ...props
 }) => {
   const cardContent = (
@@ -37,7 +43,7 @@ const Card: FC<Props> = ({
     <a
       href={href}
       className={styles.link}
-      target="_blank"
+      target={target || '_blank'}
       rel="noopener noreferrer"
     >
       {cardContent}

--- a/src/components/CategorySection/Category/CategoryCard/CategoryCard.tsx
+++ b/src/components/CategorySection/Category/CategoryCard/CategoryCard.tsx
@@ -28,6 +28,7 @@ const CategoryCard = ({ link, editing, ...editProps }: CategoryCardProps) => {
     <Card
       href={!editing && linkUrl}
       className={styles.container}
+      target={link.target}
       link={link}
       data-testid="category-card"
     >

--- a/src/components/EditLinkModal/transforms.ts
+++ b/src/components/EditLinkModal/transforms.ts
@@ -2,6 +2,18 @@ import { EditModalField, Entities } from './EditLinkModal'
 
 export const transformEntityToFields = (link: Entities): EditModalField[] =>
   Object.entries(link).map(([name, value]): EditModalField => {
+    if (name === 'target') {
+      return {
+        type: 'select',
+        label: name,
+        value: value ?? '_blank',
+        options: [
+          { label: 'New Tab', value: '_blank' },
+          { label: 'Same Tab', value: '_self' },
+        ],
+      }
+    }
+
     return {
       type: 'input',
       label: name,

--- a/src/components/FeaturedSection/FeaturedCard/FeaturedCard.tsx
+++ b/src/components/FeaturedSection/FeaturedCard/FeaturedCard.tsx
@@ -31,6 +31,7 @@ const FeaturedCard: FC<Props> = ({ link, editing, ...editingProps }) => {
 
   const cardProps = {
     background: backgroundUrl,
+    target: link?.target,
     link,
   }
 

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -136,11 +136,11 @@ const SearchBar = () => {
               <span className={styles.provider}>{name}</span> {searchTerm}
             </a>
           ))}
-        {results.map(({ name, url, featured }, index) => (
+        {results.map(({ name, url, featured, link }, index) => (
           <a
             key={index}
             href={url}
-            target="__blank"
+            target={link?.target || '_blank'}
             className={styles.result}
             ref={(el) =>
               el && (resultsRef.current[index + providers.length + 1] = el)

--- a/src/modules/config/constants.ts
+++ b/src/modules/config/constants.ts
@@ -24,6 +24,7 @@ export const DEFAULT_LINK: LinksEntity = {
   name: '',
   link: '',
   tags: '',
+  target: '_blank',
 }
 
 export const DEFAULT_FEATURED_LINK: FeaturedEntity = {
@@ -31,6 +32,7 @@ export const DEFAULT_FEATURED_LINK: FeaturedEntity = {
   link: '',
   background: DEFAULT_BG,
   tags: '',
+  target: '_blank',
 }
 
 export const DEFAULT_CATEGORY: Omit<CategoriesEntity, 'links'> = {
@@ -52,6 +54,7 @@ export const CONFIG_ENTITY_SCHEMA: JSONSchemaType<ConfigEntity> = {
           link: { type: 'string' },
           tags: { type: 'string', nullable: true },
           background: { type: 'string', nullable: true },
+          target: { type: 'string', enum: ['_self', '_blank'], nullable: true },
         },
         required: ['link', 'name'],
       },
@@ -70,6 +73,7 @@ export const CONFIG_ENTITY_SCHEMA: JSONSchemaType<ConfigEntity> = {
                 name: { type: 'string' },
                 link: { type: 'string' },
                 tags: { type: 'string', nullable: true },
+                target: { type: 'string', enum: ['_self', '_blank'], nullable: true },
               },
               required: ['link', 'name'],
             },

--- a/src/modules/config/types.ts
+++ b/src/modules/config/types.ts
@@ -10,6 +10,11 @@ export interface LinksEntity {
   name: string
   link: string
   tags?: string
+  /**
+   * Where should the link open?
+   * Defaults to `_blank` to preserve existing behaviour.
+   */
+  target?: string
 }
 
 export interface FeaturedEntity extends LinksEntity {


### PR DESCRIPTION
## Summary
- add `target` property to links and featured links
- let cards and search results honor per-link targets
- expose target selection in edit modal and validation schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689766535bf48329a79e25b759d11f9e