### PR TITLE
Enable Listening to IPv6

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,5 +1,6 @@
 server {
     listen       80;
+    listen       [::]:80;
     server_name  localhost;
 
     location / {


### PR DESCRIPTION
If you are running containers on an IPv6 enabled host and are supplying IPv6 addresses to containers, connecting to the container is failing via IPv6.
If I am connecting to the host->container remotely, docker-proxy prefers connecting via IPv6 and also fails. Enabling nginx to listen to IPv6 as well as legacy IP addresses fixes this:

**Before patch:**
```
root@XXX:~/hiccup# telnet 172.17.2.2 80
Trying 172.17.2.2...
Connected to 172.17.2.2.
Escape character is '^]'.
^CConnection closed by foreign host.

root@XXX:~/hiccup# telnet 2001:678:XXX::2 80
Trying 2001:678:XXX::2...
telnet: Unable to connect to remote host: Connection refused
```

**After patch:**
```
root@XXX:~/hiccup# telnet 172.17.2.2 80
Trying 172.17.2.2...
Connected to 172.17.2.2.
Escape character is '^]'.
^CConnection closed by foreign host.

root@XXX:~/hiccup# telnet 2001:678:XXX::2 80
Trying 2001:678:XXX::2...
Connected to 2001:678:XXX::2.
Escape character is '^]'.
^CConnection closed by foreign host.

```